### PR TITLE
Daily Sales report fails for February

### DIFF
--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -152,7 +152,8 @@ function pmpro_report_sales_page()
 	if($period == "daily")
 	{
 		$startdate = $year . '-' . substr("0" . $month, strlen($month) - 1, 2) . '-01';
-		$enddate = $year . '-' . substr("0" . $month, strlen($month) - 1, 2) . '-31';
+                $days_in_month = cal_days_in_month( CAL_GREGORIAN, $month, $year );
+                $enddate = $year . '-' . substr("0" . $month, strlen($month) - 1, 2) . '-'. $days_in_month;
 		$date_function = 'DAY';
 		$currently_in_period = ( intval( date( 'Y' ) ) == $year && intval( date( 'n' ) ) == $month );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Daily Sales report fails for February, June, September as it directly uses 31 as the days in month value.
SQL returns: Error Code: 1525. Incorrect DATETIME value: '2021-02-31'

Resolves [x].

### How to test the changes in this Pull Request:

1. Select "Memberships->Reports->Sales and Revenue->Details"
2. Select "Daily->Revenue->for February->2021"
3. Click "Generate".
4. You will get empty report - no data.

### Other information:
Update uses exact quantity of days in month for the year to build the end of month date string, not just '31' constant as it was before. My own test ran this fix successfully.

* [ ] Have you successfully run tests with your changes locally?

[x]

### Changelog entry

Fix: Daily sales and revenue report uses exact quantity of days in month for the year to fix the issue for months with less than 31 day.
